### PR TITLE
do not instantiate firebase-node

### DIFF
--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -68,7 +68,7 @@ module.exports = new Command("database:push <path> [infile]")
             utils.logSuccess("Data pushed successfully");
             logger.info();
             logger.info(clc.bold("View data at:"), consoleUrl);
-            return resolve(new Firebase(refurl));
+            return resolve();
           })
         );
       });


### PR DESCRIPTION
fixes #962

### Description

See #962 
Only the database:push command seems to instantiate Firebase when it completes. This starts some background tasks causing the node process to never exit. This seems an oversight as all other commands simply call `resolve()`

